### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [0.1.3] - 2023-10-24
 
 ## Added

--- a/helm/memcached/values.yaml
+++ b/helm/memcached/values.yaml
@@ -1,6 +1,6 @@
 memcached:
   image:
-    registry: docker.io
+    registry: gsoci.azurecr.io
     repository: giantswarm/bitnami-memcached
     tag: 1.6.21
     pullPolicy: IfNotPresent
@@ -38,7 +38,7 @@ memcached:
   metrics:
     enabled: true
     image:
-      registry: docker.io
+      registry: gsoci.azurecr.io
       repository: giantswarm/bitnami-memcached-exporter
       tag: 0.13.0
       pullPolicy: IfNotPresent


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
